### PR TITLE
Added Toggle Command Pallet and fixed extra spacer.

### DIFF
--- a/lib/tool-bar-atom.coffee
+++ b/lib/tool-bar-atom.coffee
@@ -116,9 +116,8 @@ module.exports =
         'callback': 'window:toggle-dev-tools'
         'tooltip': 'Toggle Developer Tools'
 
-    @toolBar.addSpacer()
-
     if atom.packages.loadedPackages['git-plus']
+      @toolBar.addSpacer()
       @toolBar.addButton
         'icon' : 'git-plain'
         'callback' : 'git-plus:menu'
@@ -161,6 +160,11 @@ module.exports =
         'tooltip': 'HTML Preview'
 
     @toolBar.addSpacer()
+    @toolBar.addButton
+      icon: 'navicon-round'
+      callback: 'command-palette:toggle'
+      tooltip: 'Toggle Command Palette'
+      iconset: 'ion'
     @toolBar.addButton
       'icon': 'gear'
       'callback': 'settings-view:open'


### PR DESCRIPTION
Line 120 - Fixed extra spacer if user hasn’t got ‘git-plus’.
<img width="49" alt="screen shot 2016-05-05 at 17 36 15" src="https://cloud.githubusercontent.com/assets/6761721/15049909/bc1110ee-12e8-11e6-8caa-ded22c49c7ac.png">

Lines 164-168 - Adds a button to toggle ‘Command Pallet’.
<img width="49" alt="screen shot 2016-05-05 at 17 37 42" src="https://cloud.githubusercontent.com/assets/6761721/15049912/c05f9abc-12e8-11e6-853b-933bd30943e8.png">
