### PR TITLE
Add platformio-ide-terminal support

### DIFF
--- a/lib/tool-bar-atom.coffee
+++ b/lib/tool-bar-atom.coffee
@@ -115,6 +115,12 @@ module.exports =
         'icon': 'terminal'
         'callback': 'terminal-plus:toggle'
         'tooltip': 'Toggle Terminal-plus'
+    else if atom.packages.loadedPackages['platformio-ide-terminal']
+      @toolBar.addSpacer()
+      @toolBar.addButton
+        'icon': 'terminal'
+        'callback': 'platformio-ide-terminal:toggle'
+        'tooltip': 'Toggle Platformio-ide-terminal'
 
     if atom.inDevMode()
 


### PR DESCRIPTION
There is an issue with terminal-plus and the last versions of atom (see jeremyramin/terminal-plus#311)

Platformio-ide-terminal is a fork of terminal-plus which solves this issue.